### PR TITLE
fix(helm-policy-generator): quote disallowedSANPattern

### DIFF
--- a/charts/helm-policy-generator/templates/policy.yaml
+++ b/charts/helm-policy-generator/templates/policy.yaml
@@ -187,7 +187,7 @@ spec:
             allowedSANPattern: {{ $value.allowedSANPattern }}
             {{- end }}
             {{- if $value.disallowedSANPattern }}
-            disallowedSANPattern: {{ $value.disallowedSANPattern }}
+            disallowedSANPattern: {{ $value.disallowedSANPattern | squote }}
             {{- end }}
 
             {{- /* Set namespaceSelector */}}


### PR DESCRIPTION
Ensures `disallowedSANPattern` is always quoted as a string to prevent potential rendering errors. 