### PR TITLE
feat(compliance): Add setValues to TailoredProfiles

### DIFF
--- a/charts/compliance-operator-full-stack/Chart.yaml
+++ b/charts/compliance-operator-full-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: compliance-operator-full-stack
 description: Master chart to deploy and configure the Compliance Operator
-version: 1.0.32
+version: 1.0.33
 home: https://github.com/tjungbauer/helm-charts/tree/main/charts/compliance-operator-full-stack
 icon: https://github.com/tjungbauer/helm-charts/raw/gh-pages/images/compliance-operator.png
 dependencies:

--- a/charts/compliance-operator-full-stack/templates/compliance/TailoredProfiles.yaml
+++ b/charts/compliance-operator-full-stack/templates/compliance/TailoredProfiles.yaml
@@ -13,11 +13,19 @@ metadata:
     {{- include "tpl.labels" $ | nindent 4 }}
 spec:
   description: {{ $value.description }}
-  {{ if .disableRule }}
+  {{ if $value.disableRules }}
   disableRules:
-  {{- range $rulekey, $rulevalue := .disableRule }}
-    - name: {{ $rulevalue.name }}
-      rationale: {{ $rulevalue.rationale }}
+  {{- range $rule := $value.disableRules }}
+    - name: {{ $rule.name }}
+      rationale: {{ $rule.rationale | quote }}
+  {{- end }}
+  {{- end }}
+  {{ if $value.setValues }}
+  setValues:
+  {{- range $val := $value.setValues }}
+    - name: {{ $val.name }}
+      rationale: {{ $val.rationale | quote }}
+      value: {{ $val.value | quote }}
   {{- end }}
   {{- end }}
   extends: {{ $value.extends }}

--- a/charts/compliance-operator-full-stack/values.yaml
+++ b/charts/compliance-operator-full-stack/values.yaml
@@ -103,11 +103,20 @@ compliance:
         # This Profile must exist.
         extends: ocp4-cis
         # -- A list of rules that might be disabled.
-        disableRule:
+        disableRules:
           # -- Name of the rule that shall be disabled
         - name: ocp4-scc-limit-container-allowed-capabilities
           # -- A Reason why this rule is excluded.
           rationale: Disabling CIS-OCP 5.2.8 that will always be triggered as long nutanix-csi does not provide SCC configuration
+
+        # -- A list of variables to set, used for tuning rules instead of disabling them.
+        setValues:
+          # -- The name of the variable in the base profile to override.
+        - name: "ocp4-var-sccs-with-allowed-capabilities-regex"
+          # -- The justification for setting this variable.
+          rationale: "To exclude extra SCC's from OCP-CIS rule"
+          # -- The new value for the variable
+          value: ^noobaa$|^rook-ceph-csi$|^privileged|^hostnetwork-v2|^nonroot-v2|^restricted-v2$
 
     # -- A list of Profiles that shall be used for scanning
     profiles:


### PR DESCRIPTION
- This PR introduces the ability to use `setValues` within `TailoredProfiles` for the compliance-operator-full-stack chart.   
- The chart version has been bumped to `1.0.33` to reflect these changes.