### PR TITLE
feat: add customization options for Secured Cluster deployment defaults

### DIFF
--- a/charts/rhacs-setup/Chart.yaml
+++ b/charts/rhacs-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rhacs-setup
 description: Master chart to deploy RHACS operator, initialize it and do some configuration using API Calls
-version: 1.0.42
+version: 1.0.43
 home: https://github.com/tjungbauer/helm-charts/tree/main/charts/rhacs-setup
 icon: https://github.com/tjungbauer/helm-charts/raw/gh-pages/images/acs.png
 dependencies:
@@ -52,3 +52,5 @@ annotations:
       description: "fixed yaml syntax for declarative configurations"
     - kind: changed
       description: (1.0.42) - Add Chart.lock for reproducible installs, refresh resolved dependencies, maintainer email
+    - kind: added
+      description: (1.0.43) - Added .spec.customize.deploymentDefaults to SecuredCluster CRD to allow default placement on infra nodes. Contributor mcapala

--- a/charts/rhacs-setup/templates/rhacs/secured-cluster.yaml
+++ b/charts/rhacs-setup/templates/rhacs/secured-cluster.yaml
@@ -15,6 +15,14 @@ spec:
   {{ if .Values.rhacs.secured_cluster.centralEndpoint }}
   centralEndpoint: {{ .Values.rhacs.secured_cluster.centralEndpoint }}
   {{- end }}
+  customize:
+    deploymentDefaults:
+{{- if .Values.rhacs.secured_cluster.customize.deploymentDefaults.nodeSelector }}
+{{- include "tpl.nodeSelector" .Values.rhacs.secured_cluster.customize.deploymentDefaults | indent 4 }}
+{{- end }}
+{{- if .Values.rhacs.secured_cluster.customize.deploymentDefaults.tolerations }}
+{{ include "tpl.tolerations" .Values.rhacs.secured_cluster.customize.deploymentDefaults.tolerations | indent 6 }}
+{{- end }}
   {{- /* SCANNER */}}
   {{- if eq (.Values.rhacs.scanner.enabled | toString ) "true" }}
   {{- if eq (.Values.rhacs.central.enabled | toString ) "true" }}

--- a/charts/rhacs-setup/values.yaml
+++ b/charts/rhacs-setup/values.yaml
@@ -472,15 +472,15 @@ rhacs:
       deploymentDefaults:
         # -- If you want all components of the secured cluster to only run on specific nodes, you can
         # configure tolerations of tainted nodes here. This will be applied to all components of the secured cluster.
-        tolerations:
-          - effect: NoSchedule
-            key: infra
-            operator: Equal
-            value: reserved
-          - effect: NoSchedule
-            key: infra
-            operator: Equal
-            value: reserved
+        # tolerations:
+        #   - effect: NoSchedule
+        #     key: infra
+        #     operator: Equal
+        #     value: reserved
+        #   - effect: NoSchedule
+        #     key: infra
+        #     operator: Equal
+        #     value: reserved
 
         # - Set node selector for all components of the secured cluster
         # nodeSelector:

--- a/charts/rhacs-setup/values.yaml
+++ b/charts/rhacs-setup/values.yaml
@@ -467,6 +467,26 @@ rhacs:
     # @default -- empty
     centralEndpoint: ''
 
+    # -- Customizations to apply on all Secured Cluster Services components
+    customize:
+      deploymentDefaults:
+        # -- If you want all components of the secured cluster to only run on specific nodes, you can
+        # configure tolerations of tainted nodes here. This will be applied to all components of the secured cluster.
+        tolerations:
+          - effect: NoSchedule
+            key: infra
+            operator: Equal
+            value: reserved
+          - effect: NoSchedule
+            key: infra
+            operator: Equal
+            value: reserved
+
+        # - Set node selector for all components of the secured cluster
+        # nodeSelector:
+        #   key: kubernetes.io/role
+        #   value: infra
+
     # -- Settings for Sensor
     sensor:
       # -- If you want this component to only run on specific nodes, you can


### PR DESCRIPTION
SecuredCluster CRD allows setting of default tolerations/nodeSelector for all components through .spec.customize.deploymentDefaults. I added support of setting this configuration to the rhacs-setup chart. Now if you want to run whole ACS on infra nodes for example, you set up tolerations/nodeSelector in one place instead of for every component individually.