### PR TITLE
Fix indent LokiStack.yaml placements

### DIFF
--- a/charts/helper-lokistack/Chart.lock
+++ b/charts/helper-lokistack/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: tpl
   repository: https://charts.stderr.at/
   version: 1.0.27
-digest: sha256:a37fcb0815b19994db4bf2f0118d6b5051b8c40e2db8d7c60ede6a45ce133ea7
-generated: "2026-03-29T18:55:42.078679+02:00"
+digest: sha256:38b18a9c778d84cdfd1d43833339bdcce14ca540b8081ec162df4af428c04331
+generated: "2026-06-07T08:04:20.89591+02:00"

--- a/charts/helper-lokistack/Chart.yaml
+++ b/charts/helper-lokistack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: helper-lokistack
 description: The only purpose of this helper chart is to provide a template for the LokiStack Custom Resource, so it must not be re-defined for multiple services.
-version: 1.0.22
+version: 1.0.23
 home: https://github.com/tjungbauer/helm-charts/tree/main/charts/helper-lokistack
 icon: https://github.com/tjungbauer/helm-charts/raw/gh-pages/images/loki.png
 maintainers:
@@ -10,7 +10,7 @@ maintainers:
     url: https://blog.stderr.at/
 dependencies:
   - name: tpl
-    version: ~1.0.27
+    version: 1.0.27
     repository: https://charts.stderr.at/
 sources:
   - https://github.com/tjungbauer/helm-charts
@@ -46,3 +46,5 @@ annotations:
       description: added possibility to configure network policy ruleset
     - kind: changed
       description: (1.0.22) - Add Chart.lock for reproducible installs, refresh resolved dependencies, maintainer email
+    - kind: fixed
+      description: (1.0.23) - fixed indentation in LokiStack template and podplacement section (PR 82 - spre4dy)

--- a/charts/helper-lokistack/templates/LokiStack.yaml
+++ b/charts/helper-lokistack/templates/LokiStack.yaml
@@ -129,7 +129,7 @@ spec:
     {{- if .podPlacements.compactor }}
     compactor:
       {{- if .podPlacements.compactor.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.compactor | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.compactor | indent 6 }}
       {{- end }}
 
       {{- if .podPlacements.compactor.tolerations }}
@@ -141,7 +141,7 @@ spec:
     {{- if .podPlacements.distributor }}
     distributor:
       {{- if .podPlacements.distributor.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.distributor | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.distributor | indent 6 }}
       {{- end }}
       {{- if .podPlacements.distributor.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.distributor.tolerations | indent 6 }}
@@ -152,7 +152,7 @@ spec:
     {{- if .podPlacements.gateway }}
     gateway:
       {{- if .podPlacements.gateway.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.gateway | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.gateway | indent 6 }}
       {{- end }}
       {{- if .podPlacements.gateway.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.gateway.tolerations | indent 6 }}
@@ -163,7 +163,7 @@ spec:
     {{- if .podPlacements.indexGateway }}
     indexGateway:
       {{- if .podPlacements.indexGateway.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.indexGateway | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.indexGateway | indent 6 }}
       {{- end }}
       {{- if .podPlacements.indexGateway.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.indexGateway.tolerations | indent 6 }}
@@ -174,7 +174,7 @@ spec:
     {{- if .podPlacements.ingester }}
     ingester:
       {{- if .podPlacements.ingester.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.ingester | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.ingester | indent 6 }}
       {{- end }}
       {{- if .podPlacements.ingester.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.ingester.tolerations | indent 6 }}
@@ -185,7 +185,7 @@ spec:
     {{- if .podPlacements.querier }}
     querier:
       {{- if .podPlacements.querier.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.querier | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.querier | indent 6 }}
       {{- end }}
       {{- if .podPlacements.querier.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.querier.tolerations | indent 6 }}
@@ -196,7 +196,7 @@ spec:
     {{- if .podPlacements.queryFrontend }}
     queryFrontend:
       {{- if .podPlacements.queryFrontend.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.queryFrontend | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.queryFrontend | indent 6 }}
       {{- end }}
       {{- if .podPlacements.queryFrontend.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.queryFrontend.tolerations | indent 6 }}
@@ -207,7 +207,7 @@ spec:
     {{- if .podPlacements.ruler }}
     ruler:
       {{- if .podPlacements.ruler.nodeSelector }}
-        {{- include "tpl.nodeSelector" .podPlacements.ruler | indent 4 }}
+        {{- include "tpl.nodeSelector" .podPlacements.ruler | indent 6 }}
       {{- end }}
       {{- if .podPlacements.ruler.tolerations }}
 {{ include "tpl.tolerations" .podPlacements.ruler.tolerations | indent 6 }}


### PR DESCRIPTION
Hey,
we just checked a rendering problem. It seems that we need 6 whitespaces instead of 4.
BR
Markus